### PR TITLE
Fixed misspelled header key value in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _API Url: <code>https://web.spaggiari.eu/rest/</code>_
 
 ## Request Header
 - User-Agent: <code>CVVS/std/4.1.7 Android/10</code>
-- Z-Dev-Apikey: <code>Tg1NWEwNGIgIC0K</code>
+- Z-Dev-ApiKey: <code>Tg1NWEwNGIgIC0K</code>
 - ContentsDiary-Type: <code>application/json</code>
 
 _Warning: without these headers, the request will fail._


### PR DESCRIPTION
## Fixed misspelled header key value in READEME.md

ENG: It should be `ApiKey`, not `Apikey`. Making this PR to save future users a lot of headaches.

ITA: Dovrebbe essere `ApiKey`, non `Apikey`. Faccio questa PR per risparmiare agli utenti futuri molti mal di testa.